### PR TITLE
Remove package manager installation instructions from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ emulating "user activity" and preventing screen-saver from locking up desktop.
 
 ## Installation
 
-  - Download and install Arduino IDE from their website (https://www.arduino.cc/en/Main/Software) or from your package repository: ```apt-get install arduino```.
+  - Download and install Arduino IDE from their website (https://www.arduino.cc/en/Main/Software).
   - Connect your Arduino board (via onboard micro USB port) to your computer USB port.
   - Open Arduino IDE and open project ```mouse_jiggler.ino``` file from this repository.
   - In Arduino IDE choose device type (```TOOLS > Board > Arduno Micro``` or similar) and port where programmer is connected to (```TOOLS > Port > ...```).


### PR DESCRIPTION
Due to [license documentation issues](https://github.com/arduino/Arduino/pull/2703), most package managers provide a [version of the Arduino IDE that is outdated by 5 years](https://github.com/arduino/Arduino/releases/tag/1.0.5). For this reason, recommending installation of the Arduino IDE from a package manager is a bad idea.